### PR TITLE
Set the transformed content as a Buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = function (opts) {
             files[file].jstransformer_outputFormat = transformer.outputFormat
             // Remove an extension from the end.
             files[file].jstransformer_filepath.pop()
-            files[file].contents = result.body
+            files[file].contents = new Buffer(result.body)
             done()
           }, function (err) {
             files[file].jstransformer_done = true


### PR DESCRIPTION
I stumbled upon this while further transforming files with [metalsmith-layouts](https://github.com/superwolff/metalsmith-layouts). It only works on utf8 encoded buffers, the check failed on plain strings.