### PR TITLE
Add .engineOptions and .engineLocals

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.10.0: 2016-12-16
+
+- Added `.engineOptions` and `.engineLocals`, allowing changes to how each engine functions
+
 ## v0.9.0: 2016-12-02
 
 - Updated dependencies

--- a/README.md
+++ b/README.md
@@ -143,6 +143,35 @@ The pattern used to find your layouts. Defaults to `layouts/**`.
 
 If provided, will be used as the default layout for content that doesn't have a layout explicitly defined. Defaults to `null`.
 
+### `.engineOptions`
+
+Allows passing in options for the given engines.
+
+``` js
+engineOptions: {
+  // Add our own SASS include paths.
+  scss: {
+    includePaths: [
+      'styles/mystyles',
+      'node_modules/bootstrap'
+    ]
+  }
+}
+```
+
+### `.engineLocals`
+
+Allows passing in local variables for the given engines.
+
+``` js
+engineLocals: {
+  // All Twig templates will have the `baseURL` local variable.
+  twig: {
+    baseURL: 'http://mywebsite.com/'
+  }
+}
+```
+
 ## License
 
 MIT

--- a/test/fixtures/engine-options/expected/components/included.html
+++ b/test/fixtures/engine-options/expected/components/included.html
@@ -1,0 +1,1 @@
+<div class="included">This is included.html</div>

--- a/test/fixtures/engine-options/expected/includer-test.html
+++ b/test/fixtures/engine-options/expected/includer-test.html
@@ -1,0 +1,2 @@
+<h1>Twig Title!</h1>
+<div class="included">This is included.html</div>

--- a/test/fixtures/engine-options/expected/with-title-pretty-false.html
+++ b/test/fixtures/engine-options/expected/with-title-pretty-false.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html lang="en"><head><title>Hello World</title></head><body><h1>Hello World</h1></body></html>

--- a/test/fixtures/engine-options/expected/with-title-pretty.html
+++ b/test/fixtures/engine-options/expected/with-title-pretty.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Hello World</title>
+  </head>
+  <body>
+    <h1>Hello World</h1>
+  </body>
+</html>

--- a/test/fixtures/engine-options/expected/with-title.html
+++ b/test/fixtures/engine-options/expected/with-title.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Hello World</title>
+  </head>
+  <body>
+    <h1>Hello World</h1>
+  </body>
+</html>

--- a/test/fixtures/engine-options/expected/without-title-pretty-false.html
+++ b/test/fixtures/engine-options/expected/without-title-pretty-false.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html lang="en"><head><title>Goodbye World!</title></head><body><h1>Goodbye World!</h1></body></html>

--- a/test/fixtures/engine-options/expected/without-title-pretty.html
+++ b/test/fixtures/engine-options/expected/without-title-pretty.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Goodbye World!</title>
+  </head>
+  <body>
+    <h1>Goodbye World!</h1>
+  </body>
+</html>

--- a/test/fixtures/engine-options/expected/without-title.html
+++ b/test/fixtures/engine-options/expected/without-title.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Goodbye World!</title>
+  </head>
+  <body>
+    <h1>Goodbye World!</h1>
+  </body>
+</html>

--- a/test/fixtures/engine-options/src/components/included.html
+++ b/test/fixtures/engine-options/src/components/included.html
@@ -1,0 +1,1 @@
+<div class="included">This is included.html</div>

--- a/test/fixtures/engine-options/src/includer-test.twig
+++ b/test/fixtures/engine-options/src/includer-test.twig
@@ -1,0 +1,2 @@
+<h1>{{ pageTitle }}</h1>
+{% include "@comps/included.html" %}

--- a/test/fixtures/engine-options/src/with-title-pretty-false.pug
+++ b/test/fixtures/engine-options/src/with-title-pretty-false.pug
@@ -1,0 +1,10 @@
+---
+pageTitle: Hello World
+pretty: false
+---
+doctype html
+html(lang="en")
+  head
+    title= pageTitle
+  body
+    h1= pageTitle

--- a/test/fixtures/engine-options/src/with-title-pretty.pug
+++ b/test/fixtures/engine-options/src/with-title-pretty.pug
@@ -1,0 +1,10 @@
+---
+pageTitle: Hello World
+pretty: true
+---
+doctype html
+html(lang="en")
+  head
+    title= pageTitle
+  body
+    h1= pageTitle

--- a/test/fixtures/engine-options/src/with-title.pug
+++ b/test/fixtures/engine-options/src/with-title.pug
@@ -1,0 +1,9 @@
+---
+pageTitle: Hello World
+---
+doctype html
+html(lang="en")
+  head
+    title= pageTitle
+  body
+    h1= pageTitle

--- a/test/fixtures/engine-options/src/without-title-pretty-false.pug
+++ b/test/fixtures/engine-options/src/without-title-pretty-false.pug
@@ -1,0 +1,9 @@
+---
+pretty: false
+---
+doctype html
+html(lang="en")
+  head
+    title= pageTitle
+  body
+    h1= pageTitle

--- a/test/fixtures/engine-options/src/without-title-pretty.pug
+++ b/test/fixtures/engine-options/src/without-title-pretty.pug
@@ -1,0 +1,9 @@
+---
+pretty: true
+---
+doctype html
+html(lang="en")
+  head
+    title= pageTitle
+  body
+    h1= pageTitle

--- a/test/fixtures/engine-options/src/without-title.pug
+++ b/test/fixtures/engine-options/src/without-title.pug
@@ -1,0 +1,6 @@
+doctype html
+html(lang="en")
+  head
+    title= pageTitle
+  body
+    h1= pageTitle

--- a/test/index.js
+++ b/test/index.js
@@ -66,4 +66,26 @@ testit('metalsmith-jstransformer', function () {
       pattern: '*ood*'
     }
   })
+  test('engine-options', {
+    '..': {
+      engineOptions: {
+        pug: {
+          pretty: true
+        },
+        twig: {
+          namespaces: {
+            comps: "test/fixtures/engine-options/src/components"
+          }
+        }
+      },
+      engineLocals: {
+        pug: {
+          pageTitle: "Goodbye World!"
+        },
+        twig: {
+          pageTitle: "Twig Title!"
+        }
+      }
+    }
+  })
 })


### PR DESCRIPTION
This fixes #3....

Should this be named `engineOptions` and `engineLocals` or something else? `transformerOptions` and `transformerLocals` instead?

@Zearin @calebeby @thiagodemellobueno Thoughts?