### PR TITLE
Catch and process possible exception on applying compiled layout

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,8 +103,11 @@ module.exports = function (opts) {
           })
 
           // Render the content using the template function and options.
-          var output = templates[layoutName].fn(locals)
-          files[file].contents = output
+          try {
+            files[file].contents = templates[layoutName].fn(locals)
+          } catch (e) {
+            done(e)
+          }
 
           // Allow for recursive explicit layouts.
           layoutName = files[layoutName].layout


### PR DESCRIPTION
Currently if during applying compiled layout some error occured then in Metalsmith output we only get:
```
[13:57:21] Starting 'content'...
[13:57:22] The following tasks did not complete: content
[13:57:22] Did you forget to signal async completion?

Process finished with exit code 0
```

After applying this pull request in Metalsmith output we get more useful information (and correct exit code):
```
[13:58:54] 'content' errored after 1.2 s
[13:58:54] TypeError: /Users/ych/projects/test/src/layouts/main-layout.pug:12
    10|         ul(class="menu")
    11|           each navItem in navItems
  > 12|             li(class=path.href.startsWith(navItem.path.href) ? "active" : "")
    13|               a(href=navItem.path.href) #{navItem.title}
    14| 
    15|   main(class="row column")

Cannot read property 'startsWith' of undefined
    at Object.eval (eval at wrap (/Users/ych/projects/metalsmith-jstransformer/node_modules/pug-runtime/wrap.js:6:10), <anonymous>:73:92)
    at Object.eval (eval at wrap (/Users/ych/projects/metalsmith-jstransformer/node_modules/pug-runtime/wrap.js:6:10), <anonymous>:92:4)
    at Object.template [as fn] (eval at wrap (/Users/ych/projects/metalsmith-jstransformer/node_modules/pug-runtime/wrap.js:6:10), <anonymous>:121:78)
    at renderContent (/Users/ych/projects/metalsmith-jstransformer/index.js:107:58)
    at /Users/ych/projects/metalsmith-jstransformer/node_modules/async/dist/async.js:1007:9
    at eachOfArrayLike (/Users/ych/projects/metalsmith-jstransformer/node_modules/async/dist/async.js:940:9)
    at eachOf (/Users/ych/projects/metalsmith-jstransformer/node_modules/async/dist/async.js:990:5)
    at _asyncMap (/Users/ych/projects/metalsmith-jstransformer/node_modules/async/dist/async.js:1005:5)
    at Object.map (/Users/ych/projects/metalsmith-jstransformer/node_modules/async/dist/async.js:995:16)
    at /Users/ych/projects/metalsmith-jstransformer/index.js:217:19

Process finished with exit code 1
```
