### PR TITLE
Delete plugin auxiliary metadata from files

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,6 +193,16 @@ module.exports = function (opts) {
       done()
     }
 
+    /**
+     * Delete auxiliary metadata from the given file if exist.
+     */
+    function deleteAuxiliaryMetadata(file, done) {
+      delete files[file].jstransformerOutputFormat
+      delete files[file].jstransformerFilePath
+      delete files[file].jstransformerDone
+      done()
+    }
+
     // TODO: Clean up async function chain tree.
     // Compile all layouts.
     async.map(layouts, compileLayout, function (err) {
@@ -216,7 +226,14 @@ module.exports = function (opts) {
                     done(err)
                   } else {
                     // Now rename all the files.
-                    async.map(Object.keys(files), renameFile, done)
+                    async.map(Object.keys(files), renameFile, function (err) {
+                      if (err) {
+                        done(err)
+                      } else {
+                        // Now delete auxiliary metadata from files.
+                        async.map(Object.keys(files), deleteAuxiliaryMetadata, done)
+                      }
+                    })
                   }
                 })
               }


### PR DESCRIPTION
If found possibility to resolve #18 in minor harm way - just delete auxiliary metadata from files after plugin finishes its work.
So with such fix plugin could be called as many time as needed.

I tried to implement the test for this functionality, but without changing `plugins` parameter of `test` function from `Object` to `Array` it seems not possible (because this test must use the same plugin `..` several times).