### PR TITLE
Remove odd file clone on rename

### DIFF
--- a/index.js
+++ b/index.js
@@ -185,9 +185,8 @@ module.exports = function (opts) {
 
       // See if we are to now rename the file.
       if (filename !== file) {
-        var newFile = clone(files[file])
+        files[filename] = files[file]
         delete files[file]
-        files[filename] = newFile
       }
 
       done()


### PR DESCRIPTION
The previous implementation technically correct, but it breaks plugins metalsmith flow.

For example in my case `metalsmith-collections` -> `metalsmith-jstransformer` -> `metalsmith-better-excerpts` -> `metalsmith-jstransformer` file objects in collections (created by `metalsmith-collections` plugin) after clone on rename is dirrefent from file objects in global `files` collection and as result updating/changing metadata in last one does affect first one, which complitly break the intention of `metalsmith-collections` plugin.